### PR TITLE
[Feature] 마이페이지 승부예측 정답률 구현

### DIFF
--- a/src/main/java/com/woorifisa/kboxwoori/domain/user/controller/UserController.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.woorifisa.kboxwoori.domain.user.controller;
 
 import com.woorifisa.kboxwoori.domain.user.dto.UserInfoResponseDto;
 import com.woorifisa.kboxwoori.domain.user.dto.UserDto;
+import com.woorifisa.kboxwoori.domain.user.dto.UserPageResponseDto;
 import com.woorifisa.kboxwoori.domain.user.exception.NotAuthenticatedAccountException;
 import com.woorifisa.kboxwoori.domain.user.service.UserService;
 import com.woorifisa.kboxwoori.global.config.security.PrincipalDetails;
@@ -20,7 +21,7 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping({"", "/"})
-    public String index(@AuthenticationPrincipal PrincipalDetails pdetails) {
+    public String index(@AuthenticationPrincipal PrincipalDetails pdetails){
         System.out.println(pdetails.isWooriLinked());
         return "메인페이지";
     }
@@ -57,12 +58,18 @@ public class UserController {
     }
 
     @GetMapping("/api/users/woori")
-    public ResponseDto IsWooriLinked(@AuthenticationPrincipal PrincipalDetails pdetails) {
+    public ResponseDto IsWooriLinked(@AuthenticationPrincipal PrincipalDetails pdetails){
         if (pdetails == null) {
             throw NotAuthenticatedAccountException.EXCEPTION;
         }
         userService.IsWooriLinked(pdetails.getUsername());
         return ResponseDto.success();
+    }
+
+    @GetMapping("/api/users/mypage")
+    public ResponseDto mypage(@AuthenticationPrincipal PrincipalDetails pdetails){
+        UserPageResponseDto userPageResponseDto = userService.myPageUserInfo(pdetails.getUsername());
+        return ResponseDto.success(userPageResponseDto);
     }
     
 }

--- a/src/main/java/com/woorifisa/kboxwoori/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/user/dto/UserInfoResponseDto.java
@@ -32,19 +32,4 @@ public class UserInfoResponseDto {
         this.club = user.getClub();
     }
 
-    public User toEntity() {
-        User user;
-        user = User.builder()
-                .userId(userId)
-                .password(password)
-                .name(name)
-                .gender(gender)
-                .birth(birth)
-                .phone(phone)
-                .addr(addr)
-                .club(club)
-                .build();
-        return user;
-    }
-
 }

--- a/src/main/java/com/woorifisa/kboxwoori/domain/user/dto/UserPageResponseDto.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/user/dto/UserPageResponseDto.java
@@ -1,0 +1,25 @@
+package com.woorifisa.kboxwoori.domain.user.dto;
+
+import com.woorifisa.kboxwoori.domain.user.entity.Club;
+import com.woorifisa.kboxwoori.domain.user.entity.User;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UserPageResponseDto {
+    private String clubName;
+    private String name;
+    private Integer point;
+    private Integer predictedResult;
+
+    public UserPageResponseDto(User user){
+        this.clubName = user.getClub().getShortName();
+        this.name = user.getName();
+        this.point = user.getPoint();
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/woorifisa/kboxwoori/global/config/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/api/join", "/api/login", "/api/users", "/api/point", "/api/point/honeymoney").permitAll()
+                .antMatchers("/api/join", "/api/login", "/api/users", "/api/point", "/api/point/honeymoney", "/api/users/mypage").permitAll()
                 .antMatchers("/api/admin/**").access("hasRole(ROLE_ADMIN)")
                 .and()
                 .formLogin()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->
- close #40 
## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- UserPageResponseDto 생성
- 승부예측 정답률 계산하고 관련된 유저 정보 저장하는 myPageUserInfo 생성
- UserController에 mypage api 추가
  
## 📚 Reference
<!-- 참고할 사항이 있다면 적어주세요 -->
- 참고 링크 (1)
