### PR TITLE
[Feature] 승부예측 구현

### DIFF
--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/controller/PredictionController.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/controller/PredictionController.java
@@ -1,0 +1,36 @@
+package com.woorifisa.kboxwoori.domain.prediction.controller;
+
+import com.woorifisa.kboxwoori.domain.prediction.dto.PredictionRequestDto;
+import com.woorifisa.kboxwoori.domain.prediction.dto.PredictionResponseDto;
+import com.woorifisa.kboxwoori.domain.prediction.service.PredictionService;
+import com.woorifisa.kboxwoori.domain.user.exception.NotAuthenticatedAccountException;
+import com.woorifisa.kboxwoori.global.config.security.PrincipalDetails;
+import com.woorifisa.kboxwoori.global.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/predictions")
+@RequiredArgsConstructor
+public class PredictionController {
+
+    private final PredictionService predictionService;
+
+    @GetMapping
+    public ResponseDto<PredictionResponseDto> getPrediction(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        if (principalDetails == null) {
+            throw NotAuthenticatedAccountException.EXCEPTION;
+        }
+
+        PredictionResponseDto prediction = predictionService.getPrediction(principalDetails.getUsername());
+        if (predictionService.IsPredictionOngoing()) {
+            prediction.setIsEnded(true);
+        }
+
+        return ResponseDto.success(prediction);
+    }
+
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/controller/PredictionController.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/controller/PredictionController.java
@@ -33,4 +33,14 @@ public class PredictionController {
         return ResponseDto.success(prediction);
     }
 
+    @PostMapping
+    public ResponseDto savePrediction(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                      @Valid @RequestBody PredictionRequestDto predictionRequestDto) {
+        if (principalDetails == null) {
+            throw NotAuthenticatedAccountException.EXCEPTION;
+        }
+        predictionService.IsPredictionOngoing();
+        predictionService.savePrediction(principalDetails.getUsername(), predictionRequestDto);
+        return ResponseDto.success();
+    }
 }

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/dto/PredictionRequestDto.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/dto/PredictionRequestDto.java
@@ -1,0 +1,17 @@
+package com.woorifisa.kboxwoori.domain.prediction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictionRequestDto {
+
+    @NotNull(message = "모든 경기 예측 후 참여 가능합니다.")
+    private List<String> predictions;
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/dto/PredictionResponseDto.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/dto/PredictionResponseDto.java
@@ -1,0 +1,21 @@
+package com.woorifisa.kboxwoori.domain.prediction.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PredictionResponseDto {
+    private Boolean participated;
+    private Boolean isEnded = false;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> predictions;
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/exception/AllPredictionsRequiredException.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/exception/AllPredictionsRequiredException.java
@@ -1,0 +1,12 @@
+package com.woorifisa.kboxwoori.domain.prediction.exception;
+
+import com.woorifisa.kboxwoori.global.exception.CustomException;
+import com.woorifisa.kboxwoori.global.exception.CustomExceptionStatus;
+
+public class AllPredictionsRequiredException extends CustomException {
+    public static final CustomException EXCEPTION = new AllPredictionsRequiredException();
+
+    private AllPredictionsRequiredException() {
+        super(CustomExceptionStatus.ALL_PREDICTIONS_REQUIRED);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/exception/InvalidPredictionParticipationTimeException.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/exception/InvalidPredictionParticipationTimeException.java
@@ -1,0 +1,12 @@
+package com.woorifisa.kboxwoori.domain.prediction.exception;
+
+import com.woorifisa.kboxwoori.global.exception.CustomException;
+import com.woorifisa.kboxwoori.global.exception.CustomExceptionStatus;
+
+public class InvalidPredictionParticipationTimeException extends CustomException {
+    public static final CustomException EXCEPTION = new InvalidPredictionParticipationTimeException();
+
+    private InvalidPredictionParticipationTimeException() {
+        super(CustomExceptionStatus.INVALID_PREDICTION_PARTICIPATION_TIME);
+    }
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/repository/PredictionRedisRepository.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/repository/PredictionRedisRepository.java
@@ -32,6 +32,9 @@ public class PredictionRedisRepository {
         return Arrays.asList(predictions.substring(1, predictions.length() - 1).split(", "));
     }
 
+    public void savePrediction(String userId, List<String> predictions) {
+        redisTemplate.opsForHash().put(getKey(), userId, predictions.toString());
+    }
 
     public Integer getMatchCount() {
         Object matchCount = redisTemplate.opsForHash().get(getKey(), COUNT);

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/repository/PredictionRedisRepository.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/repository/PredictionRedisRepository.java
@@ -1,0 +1,56 @@
+package com.woorifisa.kboxwoori.domain.prediction.repository;
+
+import com.woorifisa.kboxwoori.domain.prediction.exception.InvalidPredictionParticipationTimeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PredictionRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String KEY = "prediction:";
+    private static final String COUNT = "match-count";
+    private static final String END_TIME = "end-time";
+
+    public Boolean hasParticipated(String userId) {
+        return redisTemplate.opsForHash().hasKey(getKey(), userId);
+    }
+
+    public List<String> getPrediction(String userId) {
+        String predictions = (String) redisTemplate.opsForHash().get(getKey(), userId);
+        if (predictions == null) {
+            return null;
+        }
+        return Arrays.asList(predictions.substring(1, predictions.length() - 1).split(", "));
+    }
+
+
+    public Integer getMatchCount() {
+        Object matchCount = redisTemplate.opsForHash().get(getKey(), COUNT);
+        if (matchCount == null) {
+            throw InvalidPredictionParticipationTimeException.EXCEPTION;
+        }
+        return Integer.valueOf(matchCount.toString());
+    }
+
+    public LocalTime getEndTime() {
+        Object endTime = redisTemplate.opsForHash().get(getKey(), END_TIME);
+        if (endTime == null) {
+            throw InvalidPredictionParticipationTimeException.EXCEPTION;
+        }
+        return LocalTime.parse(endTime.toString());
+    }
+
+    private String getKey() {
+        return KEY + LocalDate.now();
+    }
+
+}

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/service/PredictionService.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/service/PredictionService.java
@@ -40,4 +40,11 @@ public class PredictionService {
         return true;
     }
 
+    public void savePrediction(String userId, PredictionRequestDto predictionRequestDto) {
+        //TODO: 모두 예측했는지 확인 (경기 수는 가변값)
+        if (predictionRequestDto.getPredictions().size() != predictionRedisRepository.getMatchCount()) {
+            throw AllPredictionsRequiredException.EXCEPTION;
+        }
+        predictionRedisRepository.savePrediction(userId, predictionRequestDto.getPredictions());
+    }
 }

--- a/src/main/java/com/woorifisa/kboxwoori/domain/prediction/service/PredictionService.java
+++ b/src/main/java/com/woorifisa/kboxwoori/domain/prediction/service/PredictionService.java
@@ -1,0 +1,43 @@
+package com.woorifisa.kboxwoori.domain.prediction.service;
+
+import com.woorifisa.kboxwoori.domain.prediction.dto.PredictionRequestDto;
+import com.woorifisa.kboxwoori.domain.prediction.dto.PredictionResponseDto;
+import com.woorifisa.kboxwoori.domain.prediction.exception.AllPredictionsRequiredException;
+import com.woorifisa.kboxwoori.domain.prediction.exception.InvalidPredictionParticipationTimeException;
+import com.woorifisa.kboxwoori.domain.prediction.repository.PredictionRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PredictionService {
+
+    private final PredictionRedisRepository predictionRedisRepository;
+
+    public PredictionResponseDto getPrediction(String userId) {
+        if (predictionRedisRepository.hasParticipated(userId)) {
+            List<String> predictions = predictionRedisRepository.getPrediction(userId);
+            if (predictions != null) {
+                return PredictionResponseDto.builder()
+                        .participated(true)
+                        .predictions(predictions)
+                        .build();
+            }
+        }
+
+        return PredictionResponseDto.builder()
+                .participated(false)
+                .build();
+    }
+
+    public Boolean IsPredictionOngoing() {
+        if (LocalTime.now().isAfter(predictionRedisRepository.getEndTime())) {
+            throw InvalidPredictionParticipationTimeException.EXCEPTION;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/com/woorifisa/kboxwoori/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/com/woorifisa/kboxwoori/global/exception/CustomExceptionStatus.java
@@ -22,11 +22,15 @@ public enum CustomExceptionStatus {
     EVENT_IS_ENDED(1303, false, "이벤트가 마감되었습니다."),
     DUPLICATE_PARTICIPATION(1304, false, "같은 이벤트에 중복 참여는 불가합니다."),
 
+    INVALID_PREDICTION_PARTICIPATION_TIME(1400, false, "승부예측 참여 시간이 아닙니다."),
+    ALL_PREDICTIONS_REQUIRED(1401, false, "모든 경기 예측 후 참여 가능합니다."),
+
     QUIZ_ENDED(1500, false, "퀴즈 참여 시간이 아닙니다."),
     QUIZ_NOT_FOUND(1501, false, "현재 진행중인 퀴즈가 없습니다."),
     QUIZ_DUPLICATE_PARTICIPATION(1502, false, "같은 퀴즈에 중복 참여는 불가합니다."),
 
     FILE_UPLOAD(1600, false, "파일 업로드에 실패헸습니다."),
+
     POINT_OPERAION_ERROR(1700, false, "잔여 포인트가 부족합니다.");
 
     private final int status;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->
- close #62 
## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- repository에 당일 경기 수 및 승부예측 마감 시간 조회 메서드 추가
- 사용자의 당일 승부예측 제출 내역 조회 기능 구현
- 승부예측 제출 기능 구현
 
